### PR TITLE
Single image processing mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+/.idea

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.22
 
 require github.com/disintegration/imaging v1.6.2
 
-require golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 // indirect
+require golang.org/x/image v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
-golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3NCfkPxbDKRdnNE1Rpg0U=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.15.0 h1:kOELfmgrmJlw4Cdb7g/QGuB3CvDrXbqEIww/pNtNBm8=
+golang.org/x/image v0.15.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/util/args.go
+++ b/util/args.go
@@ -1,0 +1,123 @@
+package util
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+)
+
+var ErrInvalidArguments = errors.New("invalid arguments")
+
+// Args are all the possible commandline arguments
+type Args struct {
+	Datafile  string // Mutually exclusive with CRC
+	CRC       string // Mutually exclusive with Datafile
+	ImagePath string // Could be a file. Could be a dir. We'll check in verifyArgs.
+	OutPath   string // It's a string rather than a File as we won't create it until after we have confirmed everything exists.
+	Upscale   bool
+	Verbose   bool
+}
+
+// ParseArgs parses the commandline args as well as verifies that the correct set of them is provided.
+func ParseArgs() (Args, error) {
+	args := Args{}
+	flag.Usage = printUsage
+	flag.BoolVar(&args.Upscale, "upscale", false, "Resizes images less than 170 pixels high")
+	flag.BoolVar(&args.Upscale, "u", false, "Resizes images less than 170 pixels high")
+
+	flag.BoolVar(&args.Verbose, "verbose", false, "Turns on verbose logging")
+	flag.BoolVar(&args.Verbose, "v", false, "Turns on verbose logging")
+
+	flag.StringVar(&args.CRC, "crc", "", "CRC value for single image processing")
+	flag.StringVar(&args.CRC, "c", "", "CRC value for single image processing")
+
+	flag.StringVar(&args.Datafile, "datafile", "", "no-intro dat-o-matic datafile")
+	flag.StringVar(&args.Datafile, "d", "", "no-intro dat-o-matic datafile")
+
+	flag.StringVar(&args.ImagePath, "in", "", "Image input src")
+	flag.StringVar(&args.ImagePath, "i", "", "Image input src")
+
+	// Use the current working directory as the default output dir if not specified
+	// Probably should warn against this if you're using a datafile though
+	out, err := os.Getwd()
+	if err != nil {
+		return Args{}, fmt.Errorf("os.Getwd: %w", err)
+	}
+	flag.StringVar(&args.OutPath, "out", out, "Output directory")
+	flag.StringVar(&args.OutPath, "o", out, "Output directory")
+
+	flag.Parse()
+
+	args, err = verifyArgs(args)
+	if errors.Is(err, ErrInvalidArguments) {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	return args, err
+}
+
+func verifyArgs(args Args) (Args, error) {
+	if len(args.Datafile) == 0 && len(args.CRC) == 0 {
+		fmt.Println("ERROR: one of --datafile or --crc must be specified")
+		return args, ErrInvalidArguments
+	}
+	if len(args.Datafile) != 0 && len(args.CRC) != 0 {
+		fmt.Println("ERROR: --datafile and --crc are mutually exclusive")
+		return args, ErrInvalidArguments
+	}
+	if len(args.ImagePath) == 0 {
+		fmt.Println("ERROR: --in must be specified")
+		return args, ErrInvalidArguments
+	}
+	if len(args.OutPath) == 0 {
+		fmt.Println("ERROR: --out must be specified")
+		return args, ErrInvalidArguments
+	}
+
+	// Image source is the most complex: it can be a file or a directory
+	if imgSrc, err := os.Stat(args.ImagePath); errors.Is(err, os.ErrNotExist) {
+		return Args{}, fmt.Errorf("input source %s does not exist", args.ImagePath)
+	} else if err != nil {
+		return Args{}, fmt.Errorf("error opening input src %s: %w", args.ImagePath, err)
+	} else if len(args.Datafile) != 0 && !imgSrc.IsDir() {
+		fmt.Println("ERROR: --in must be a dir if --datafile is specified")
+		return args, ErrInvalidArguments
+	} else if len(args.CRC) != 0 && imgSrc.IsDir() {
+		fmt.Println("ERROR: --in must be a file if --crc is specified")
+		return args, ErrInvalidArguments
+	}
+
+	if len(args.CRC) != 0 {
+		if match, err := regexp.MatchString(`[[:xdigit:]]{8}`, args.CRC); !match {
+			return Args{}, fmt.Errorf("%s is not a valid crc32 hash", args.CRC)
+		} else if err != nil {
+			return Args{}, fmt.Errorf("regex error: %w", err)
+		}
+	}
+
+	if len(args.Datafile) > 0 {
+		if datafile, err := os.Stat(args.Datafile); errors.Is(err, os.ErrNotExist) {
+			return Args{}, fmt.Errorf("datafile %s does not exist", args.Datafile)
+		} else if err != nil {
+			return Args{}, fmt.Errorf("error opening input src %s: %w", args.Datafile, err)
+		} else if datafile.IsDir() {
+			return Args{}, fmt.Errorf("datafile %s is a directory", args.Datafile)
+		}
+	}
+	return args, nil
+}
+
+func printUsage() {
+	fmt.Println(`
+Usage of thumbnailizer:
+-d, --datafile Path to no-intro dat-o-matic datafile for multi image processing mode
+-c, --crc      CRC32 of game for single image processing mode
+-i, --in       Path to image file (for crc mode) or image directory (for datafile mode)
+-o, --out	   Output directory
+-v, --verbose  Turns on verbose logging
+-u, --upscale  Resizes images less than 170 pixels high
+-h, --help     Prints this message`)
+}

--- a/util/fs.go
+++ b/util/fs.go
@@ -17,13 +17,13 @@ func MakeDir(path string) error {
 		s, err := os.Stat(p)
 		if errors.Is(err, os.ErrNotExist) {
 			if err := os.Mkdir(p, os.ModePerm); err != nil { // Don't check for ErrExist, as we can't confirm it's a directory.
-				return fmt.Errorf("error creating output dir: %w", err)
+				return fmt.Errorf("error creating dir %s: %w", p, err)
 			}
 		} else if err != nil {
-			return fmt.Errorf("error opening output dir: %w", err)
+			return fmt.Errorf("error opening dir %s: %w", p, err)
 		} else {
 			if !s.IsDir() {
-				return fmt.Errorf("output file is not a directory")
+				return fmt.Errorf("%s exists & is not a directory", p)
 			}
 		}
 	}


### PR DESCRIPTION
A rework to allow both multi-image processing mode & single image processing mode.

For multi-image mode, pass it the following options:
* `--datafile` The no-intro dat-o-matic datafile
* `--in` The directory where the images reside
* `--out` The output directory for the bin files

For single image mode, the following options are used:
* `--crc` The crc to use for the filename
* `--in` The image to process
* `--out` The directory to output the file to

For both modes, you can also pass it `--upscale` or `--verbose`.
`--upscale` will resize any image below 175 pixels in height up to 175 pixels. (Images will always be resized down to 175 pixels in height if they're larger to avoid cropping.)
`--verbose` prints out a few extra logging messages. If you're using the multi-file mode & not seeing the image you expect generating, you may wish to try this flag.

I'll get around to adding a workflow that creates some artifacts eventually.