### PR TITLE
fix: datafile incorrectly became the working dir in crc mode

### DIFF
--- a/util/args.go
+++ b/util/args.go
@@ -124,12 +124,14 @@ func verifyArgs(args Args) (Args, error) {
 		}
 	}
 
-	datafile, err := filepath.Abs(args.Datafile)
-	if err != nil {
-		return Args{}, fmt.Errorf("error finding absolute path: %w", err)
-	}
-	args.Datafile = datafile
 	if len(args.Datafile) > 0 {
+		// Only do this after checking length as filepath.Abs("") gives you the working directory.
+		datafile, err := filepath.Abs(args.Datafile)
+		if err != nil {
+			return Args{}, fmt.Errorf("error finding absolute path: %w", err)
+		}
+		args.Datafile = datafile
+
 		if datafile, err := os.Stat(args.Datafile); errors.Is(err, os.ErrNotExist) {
 			return Args{}, fmt.Errorf("datafile %s does not exist", args.Datafile)
 		} else if err != nil {


### PR DESCRIPTION
`filepath.Abs` with an empty string gives you the current working directory. Caused issues when --crc was used, as that's mutually exclusive with --datafile.